### PR TITLE
feat: set header background to deep grey

### DIFF
--- a/weekly_production_planner.html
+++ b/weekly_production_planner.html
@@ -22,7 +22,7 @@
     }
 
     th {
-      background-color: #f2f2f2;
+      background-color: #333;
       position: sticky;
       top: 0;
       z-index: 1;
@@ -82,7 +82,7 @@
     </tbody>
     <tfoot>
       <tr>
-        <td colspan="4">Totals</td>
+        <td colspan="4">Grand Total</td>
         <td class="total-cut-plan">0</td>
         <td class="total-cut-actual">0</td>
         <td></td>


### PR DESCRIPTION
## Summary
- set table header background color to deep grey for better contrast
- rename totals row label to "Grand Total" for clarity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a15907316c832a94f8a8abfcd41370