### PR TITLE
fix: load XLSX library from available CDN version

### DIFF
--- a/weekly_production_planner.html
+++ b/weekly_production_planner.html
@@ -45,7 +45,10 @@
     }
   </style>
   <!-- SheetJS library for XLSX export -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.7/xlsx.full.min.js"></script>
+  <!-- The 0.18.7 release is not available on the CDN which caused the
+       "XLSX library not loaded" alert.  Falling back to the latest version
+       provided by the CDN fixes the issue. -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
 </head>
 <body>
   <div id="toolbar">


### PR DESCRIPTION
## Summary
- fix missing SheetJS dependency by linking to available CDN version

## Testing
- `node -e "console.log('no tests')"`


------
https://chatgpt.com/codex/tasks/task_e_68a1a2e579c8832a98a15083ded001ba