### PR TITLE
Improve chart readability in dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1268,8 +1268,15 @@
       const height = canvas.height;
       ctx.clearRect(0, 0, width, height);
 
+      const chartBackground = '#1f2633';
+      const textColor = '#e6e8ed';
+      const axisColor = '#9aa3b5';
+
+      ctx.fillStyle = chartBackground;
+      ctx.fillRect(0, 0, width, height);
+
       if (series.length === 0) {
-        ctx.fillStyle = '#666';
+        ctx.fillStyle = textColor;
         ctx.font = '12px Arial';
         ctx.fillText('Add data to see plan vs actual', 10, 24);
         return;
@@ -1284,7 +1291,7 @@
       const yFor = value => height - padding - (yScale > 0 ? value * yScale : 0);
 
       // Axes
-      ctx.strokeStyle = '#ccc';
+      ctx.strokeStyle = axisColor;
       ctx.lineWidth = 1;
       ctx.beginPath();
       ctx.moveTo(padding, padding);
@@ -1333,12 +1340,12 @@
         ctx.arc(x, actY, 3, 0, Math.PI * 2);
         ctx.fill();
 
-        ctx.fillStyle = '#333';
+        ctx.fillStyle = textColor;
         ctx.fillText(point.label, x - 14, height - padding + 14);
       });
 
       // Title, legend, max label, and cumulative label
-      ctx.fillStyle = '#333';
+      ctx.fillStyle = textColor;
       ctx.font = '12px Arial';
       ctx.fillText(title, padding, padding - 12);
       ctx.fillText(`${maxVal}`, 6, padding + 6);
@@ -1352,11 +1359,11 @@
       const legendX = width - padding - 110;
       ctx.fillStyle = '#007bff';
       ctx.fillRect(legendX, legendY - 8, 10, 10);
-      ctx.fillStyle = '#333';
+      ctx.fillStyle = textColor;
       ctx.fillText('Plan', legendX + 14, legendY);
       ctx.fillStyle = '#2e8b57';
       ctx.fillRect(legendX + 52, legendY - 8, 10, 10);
-      ctx.fillStyle = '#333';
+      ctx.fillStyle = textColor;
       ctx.fillText('Actual', legendX + 66, legendY);
     }
 


### PR DESCRIPTION
## Summary
- add dark background fill for chart canvases to avoid transparent rendering
- switch chart text and axis colors to light hues for better contrast in dark mode

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693315889a60832a92c9ad5d34f6e16a)